### PR TITLE
Add X-Application-ID header

### DIFF
--- a/docs/Access Control with JWT Token.md
+++ b/docs/Access Control with JWT Token.md
@@ -1,0 +1,37 @@
+# Access Control with JWT Token
+
+## Overview
+
+Clients using the api endpoint for tunnel `/v3/devices/{id}/services/{address}/connection` needs a jwt token to be both authenticated and authorized.
+
+Creation of the jwt is up to the client but a public cetificate that signed the jwt needs to be uploaded into the Pelion Device Management. An example flow is provided below.
+
+### Example Flow to Access Edge-Proxy Tunnel with JWT
+
+- Create a private key-public key certificate pair
+`$ openssl req -newkey rsa:2048 -nodes -keyout private.key -x509 -days 365 -out public.crt`
+
+- Upload the public certificate to the Pelion Device Management verification keys api with an admin access key created from the Pelion Device Management  (TODO: Paste a link on how to create admin access key).
+
+```
+curl -0 -v -X POST https://api.us-east-1.mbedcloud.com/v3/applications/{application-id}/verification-keys \
+2-H 'Authorization: Bearer ak_2MD...' \
+3-H 'content-type: application/json' \
+4--data-binary @- << EOF
+5{
+6    "name": "JWT-test",
+7    "certificate": "-----BEGIN CERTIFICATE-----
+8    ...
+9    -----END CERTIFICATE-----"
+10}
+11EOF
+```
+- Create a jwt in RSASHA256 format and signed it with the private key and certificate, can be done in jwt.io. The supported signing algorithms are RS256, RS384, RS512, ES256, ES384, ES512. HS256 is not supported. Make sure that the exp claus/claim exists and valid.
+
+- Access /v3/devices/{id}/services/{address}/connection with a header "X-Application-ID" corresponding to the same `{application-id}` (where the verification keys are created) and set `Authorization` header with value `Bearer {JWT}` . Without this header and bearer token the client will not be authenticated and autorized. `{id}` is the device id or gateway id and `{address}` is the `tunnel_ip:tunnel_port` format.
+
+### Required JWT Claims to Access Edge-Proxy Tunnel
+- `exp`: JWT expiration date in number of seconds since Epoch format.
+- `pelion.edge.tunnel.device_id`: The only device id that could be used to open tunnel.
+- `pelion.edge.tunnel.ip`: The only IP that could be connected over tunnel.
+- `pelion.edge.tunnel.port`: The only port that could be connected over tunnel.

--- a/docs/Access Control with JWT Token.md
+++ b/docs/Access Control with JWT Token.md
@@ -4,7 +4,7 @@
 
 Clients using the api endpoint for tunnel `/v3/devices/{id}/services/{address}/connection` can use a jwt token to restrict access to a cloud application though the edge-proxy.
 
-Creation of the jwt is up to the client but a public cetificate that signed the jwt needs to be uploaded into the Pelion Device Management. An example flow is provided below.
+Creation of the jwt is up to the client but a public cetificate that signed the jwt needs to be uploaded into the Pelion Device Management. More information on Pelion Device Management JWT keys can be found [here](https://developer.pelion.com/docs/device-management/current/user-account/jwt-keys.html).
 
 ### Example Flow to Access Edge-Proxy Tunnel with JWT
 

--- a/docs/Access Control with JWT Token.md
+++ b/docs/Access Control with JWT Token.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Clients using the api endpoint for tunnel `/v3/devices/{id}/services/{address}/connection` needs a jwt token to be both authenticated and authorized.
+Clients using the api endpoint for tunnel `/v3/devices/{id}/services/{address}/connection` can use a jwt token to restrict access to a cloud application though the edge-proxy.
 
 Creation of the jwt is up to the client but a public cetificate that signed the jwt needs to be uploaded into the Pelion Device Management. An example flow is provided below.
 
@@ -11,7 +11,7 @@ Creation of the jwt is up to the client but a public cetificate that signed the 
 - Create a private key-public key certificate pair
 `$ openssl req -newkey rsa:2048 -nodes -keyout private.key -x509 -days 365 -out public.crt`
 
-- Upload the public certificate to the Pelion Device Management verification keys api with an admin access key created from the Pelion Device Management  (TODO: Paste a link on how to create admin access key).
+- Upload the public certificate to the Pelion Device Management verification keys api with an admin access key created from the Pelion Device Management.
 
 ```
 curl -0 -v -X POST https://api.us-east-1.mbedcloud.com/v3/applications/{application-id}/verification-keys \
@@ -26,12 +26,14 @@ curl -0 -v -X POST https://api.us-east-1.mbedcloud.com/v3/applications/{applicat
 10}
 11EOF
 ```
-- Create a jwt in RSASHA256 format and signed it with the private key and certificate, can be done in jwt.io. The supported signing algorithms are RS256, RS384, RS512, ES256, ES384, ES512. HS256 is not supported. Make sure that the exp claus/claim exists and valid.
+- Create a jwt in RSASHA256 format and signed it with the private key and certificate, can be done in jwt.io. The supported signing algorithms are RS256, RS384, RS512, ES256, ES384, ES512. HS256 is not supported. Make sure that the exp clause/claim exists and valid.
 
-- Access /v3/devices/{id}/services/{address}/connection with a header "X-Application-ID" corresponding to the same `{application-id}` (where the verification keys are created) and set `Authorization` header with value `Bearer {JWT}` . Without this header and bearer token the client will not be authenticated and autorized. `{id}` is the device id or gateway id and `{address}` is the `tunnel_ip:tunnel_port` format.
+- Access /v3/devices/{id}/services/{address}/connection with a header "X-Application-ID" corresponding to the same `{application-id}` (where the verification keys are created) and set `Authorization` header with value `Bearer {JWT}` . Using jwt as bearer token without this header will cause the client not be authenticated . `{id}` is the device id or gateway id and `{address}` is the `tunnel_ip:tunnel_port` format.
 
-### Required JWT Claims to Access Edge-Proxy Tunnel
+### JWT Claims to Access Edge-Proxy Tunnel
+Required claims
 - `exp`: JWT expiration date in number of seconds since Epoch format.
-- `pelion.edge.tunnel.device_id`: The only device id that could be used to open tunnel.
-- `pelion.edge.tunnel.ip`: The only IP that could be connected over tunnel.
-- `pelion.edge.tunnel.port`: The only port that could be connected over tunnel.
+Optional claims. Jwt token can specify one or all of the claims below to restrict access to the application
+- `pelion.edge.tunnel.device_id`:  The only device id that could be used to open tunnel, if specified.
+- `pelion.edge.tunnel.ip`: The only IP that could be connected over tunnel, if specified.
+- `pelion.edge.tunnel.port`:  The only port that could be connected over tunnel, if specified.

--- a/docs/Access Control with JWT Token.md
+++ b/docs/Access Control with JWT Token.md
@@ -31,9 +31,10 @@ curl -0 -v -X POST https://api.us-east-1.mbedcloud.com/v3/applications/{applicat
 - Access /v3/devices/{id}/services/{address}/connection with a header "X-Application-ID" corresponding to the same `{application-id}` (where the verification keys are created) and set `Authorization` header with value `Bearer {JWT}` . Using jwt as bearer token without this header will cause the client not be authenticated . `{id}` is the device id or gateway id and `{address}` is the `tunnel_ip:tunnel_port` format.
 
 ### JWT Claims to Access Edge-Proxy Tunnel
-Required claims
+#### Required claims
 - `exp`: JWT expiration date in number of seconds since Epoch format.
-Optional claims. Jwt token can specify one or all of the claims below to restrict access to the application
+##### Optional claims. 
+Jwt token can specify one or all of the claims below to restrict access to the application
 - `pelion.edge.tunnel.device_id`:  The only device id that could be used to open tunnel, if specified.
 - `pelion.edge.tunnel.ip`: The only IP that could be connected over tunnel, if specified.
 - `pelion.edge.tunnel.port`:  The only port that could be connected over tunnel, if specified.

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ var applicationID string
 func main() {
 	flag.StringVar(&listenURI, "listen-uri", "0.0.0.0:8181", "Local TCP server address")
 	flag.StringVar(&cloudURI, "cloud-uri", "", "Cloud URI that edge tunneling service is running on")
-	flag.StringVar(&apiKey, "api-key", "", "API Key that needs to connect to edge tunneling service")
+	flag.StringVar(&apiKey, "api-key", "", "API Key or JWT Token that needs to connect to edge tunneling service")
 	flag.StringVar(&applicationID, "application-id", "", "If JWT is used instead of api-key, application-id is needed")
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -14,11 +14,13 @@ import (
 var listenURI string
 var cloudURI string
 var apiKey string
+var applicationID string
 
 func main() {
 	flag.StringVar(&listenURI, "listen-uri", "0.0.0.0:8181", "Local TCP server address")
 	flag.StringVar(&cloudURI, "cloud-uri", "", "Cloud URI that edge tunneling service is running on")
 	flag.StringVar(&apiKey, "api-key", "", "API Key that needs to connect to edge tunneling service")
+	flag.StringVar(&applicationID, "application-id", "", "If JWT is used instead of api-key, application-id is needed")
 	flag.Parse()
 
 	if cloudURI == "" {
@@ -63,6 +65,7 @@ func main() {
 				"Authorization": []string{
 					"Bearer " + apiKey,
 				},
+				"X-Application-ID": []string{applicationID},
 			})
 
 			if err != nil {


### PR DESCRIPTION
 X-Application-ID header is needed when using JWT.
 In fact api-key will not be authorize to use the tunnel, should use a formed jwt.

